### PR TITLE
fix a bug when photos title is Untitled

### DIFF
--- a/popup_script.js
+++ b/popup_script.js
@@ -31,7 +31,7 @@
 
 				var title = $(xml).find("title");
 
-				if( title ) {
+				if( title != null && title.text() != "" ) {
 					var urlParts = url.split(".");
 					title = filenameSanitize((title.text() || "").trim(), "_") + "." + urlParts[urlParts.length - 1];
 					title = title.split("?")[0];


### PR DESCRIPTION
Download link has been broken when photos title is Untitled.
ex) https://www.flickr.com/photos/120688567@N03/15055280211/
