### PR TITLE
disable downloads where can_download = 0

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -98,6 +98,4 @@ Set Id: <input id="setId" class="textInput" /> <button id="setOk">Load</button> 
 
 <div id="imgContainer"></div>
 
-<div id="disclaimer">Don't use this extension to download photos that you don't have permission to!</div>
-
 <img id="loading" src="loading.gif" />

--- a/popup_script.js
+++ b/popup_script.js
@@ -57,6 +57,12 @@
 
 			success: function(xml) {
 
+				var canDownload = $(xml).find("sizes").first().attr("candownload");
+				if (canDownload == 0) {
+					$("#loading").hide();
+					displayMessage("Downloads are disabled for this photo");
+					return;
+				}
 				var size = $(xml).find("size");
 				var thumbUrl = size.first().attr("source");
 				var bigUrl = size.last().attr("source");
@@ -153,6 +159,19 @@
 				.addClass("loadMore")
 				.appendTo( $("#imgContainer") );
 		}
+	}
+
+	// display a message that can be hidden
+	function displayMessage(msg) {
+
+		$("<a/>")
+			.text(msg)
+			.attr("href", "#")
+			.on("click", function() {
+				$(this).remove();
+			})
+			.addClass("loadMore")
+			.appendTo( $("#imgContainer") );
 	}
 
 	// Check if Auto Download is active


### PR DESCRIPTION
Hi, Hwan-Joon from Flickr here - I sent you an email regarding this. I took a look at the code and since you are calling getSizes, you don't even need to add extras. I've gone ahead with a simple change that disables downloads where prohibited. I didn't try to do too much on the UI end, but the logic should be simple and work the same for photos that can be downloaded. Please take a look at this as a starting point to make changes to your extension. Let me know if you have any questions.
