### PR TITLE
Fix url parsing bug

### DIFF
--- a/popup_script.js
+++ b/popup_script.js
@@ -286,7 +286,7 @@
 			var urlParts = tab.url.split("/");
 
 			// Set
-			if( urlParts[5] === "sets")
+			if( ["sets", "albums"].indexOf(urlParts[5]) > -1 )
 			{
 				$("#setId").attr("value", urlParts[6]);
 				$("#setOk").click();


### PR DESCRIPTION
Flickr has supported two endpoints to access albums.
In fact, I saw "sets" and "album" in url.
So we should fix url parser.
## Examples

https://www.flickr.com/photos/40399956@N06/albums/72157643561183373
https://www.flickr.com/photos/40399956@N06/sets/72157643561183373
