### PR TITLE
Add support for albums

### DIFF
--- a/popup_script.js
+++ b/popup_script.js
@@ -286,7 +286,7 @@
 			var urlParts = tab.url.split("/");
 
 			// Set
-			if( urlParts[5] === "sets")
+			if( urlParts[5] === "sets" || urlParts[5] === "albums")
 			{
 				$("#setId").attr("value", urlParts[6]);
 				$("#setOk").click();


### PR DESCRIPTION
I found that DownFlickr can't parse url in albums pages sometimes.
In new web UI, the album url is 'photos/{USERNAME}/albums/{ID}'.
But this url parser does not support that format.

https://www.flickr.com/photos/nnaannoohhaa/albums/72157627089718425 : NG
https://www.flickr.com/photos/nnaannoohhaa/sets/72157627089718425 : OK
